### PR TITLE
refactor(cloudinary): comment out file cleanup after upload

### DIFF
--- a/src/helpers/upload-to-cloudinary.ts
+++ b/src/helpers/upload-to-cloudinary.ts
@@ -11,9 +11,9 @@ export async function uploadImageToCloudinary(
     });
 
     // Clean up the local file
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
-    }
+    // if (fs.existsSync(filePath)) {
+    //   fs.unlinkSync(filePath);
+    // }
 
     return {
       secure_url: result.secure_url,
@@ -22,9 +22,9 @@ export async function uploadImageToCloudinary(
     };
   } catch (error) {
     // Clean up file on error
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
-    }
+    // if (fs.existsSync(filePath)) {
+    //   fs.unlinkSync(filePath);
+    // }
     throw new Error(
       `Failed to upload image to Cloudinary: ${error instanceof Error ? error.message : "Unknown error"}`
     );


### PR DESCRIPTION
The file cleanup logic after uploading to Cloudinary has been temporarily commented out. This change is made to investigate potential issues with file handling during the upload process. The cleanup will be re-evaluated and potentially re-enabled after further testing and analysis.